### PR TITLE
Add default marking to example .jirarc in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@ jira-precommit-hook
 
 Goals:
 
-- Distributable via npm (This will eventually be pushed to a public github repo)
-- Testable
 - Commit hook script contains the bare bones needed to call into this library.
   We may want to investigate use of existing
   [pre-commit](https://www.npmjs.com/package/pre-commit) module.
@@ -17,6 +15,7 @@ Currently only configured for read-only access to JIRA.
 # Project Configuration
 
 **DESCRIPTION**
+
 In order to communicate with your JIRA server, a .jirarc file needs to be placed in the root of the repo.
 
 ```json
@@ -24,9 +23,9 @@ In order to communicate with your JIRA server, a .jirarc file needs to be placed
 	"projectName": "<Name of JIRA project - REQUIRED>",
 	"host":"<URL location of JIRA project - REQUIRED>",
 	"protocol":"[default:http|https]",
-	"port": 80,
+	"port": default:80,
 	"version": default:2,
-	"verbose": false,
-	"strictSSL": true
+	"verbose": default:false,
+	"strictSSL": default:true
 }
 ```


### PR DESCRIPTION
The README file does not clearly mark which fields of the .jirarc file have default values. It now reflects these default fields accordingly.