### PR TITLE
commit-msg hook gets copied into root .git

### DIFF
--- a/src/fs-utils.js
+++ b/src/fs-utils.js
@@ -25,7 +25,7 @@ export function findParentFolder(startDir, parentDirName) {
 
 export function copyHookFiles(gitDirectory) {
   return new Promise((fulfill, reject) => {
-    fs.createReadStream(path.resolve(path.join(__dirname, '../hooks/commit-msg')))
+    fs.createReadStream(path.join(__dirname, '../hooks/commit-msg'))
       .pipe(fs.createWriteStream(path.join(gitDirectory, '/hooks/commit-msg')))
       .on('close', (error, result) => {
         if(error) {

--- a/src/install.js
+++ b/src/install.js
@@ -1,6 +1,6 @@
 import {findParentFolder, copyHookFiles} from './fs-utils.js';
 
-let currentPath = process.env.pwd;
+let currentPath = process.cwd();
 
 try{
   copyHookFiles(findParentFolder(currentPath, '.git'));


### PR DESCRIPTION
Response to #1. Confirmed to copy commit-msg hook from node-modules/jira-precommit-hook/hooks to .git in the root of the repository.