### PR TITLE
Print out issues without matching issuetype

### DIFF
--- a/src/validation-strategies/one-valid-issue.js
+++ b/src/validation-strategies/one-valid-issue.js
@@ -5,7 +5,8 @@ function validateStrategies(issueKey, jiraClientAPI) {
   return jiraClientAPI.findIssue(issueKey)
     .then(content =>
       issueStrats[content.fields.issuetype.name].apply(content, jiraClientAPI)
-    );
+    )
+    .catch(content => Promise.reject(new Error(`${issueKey} does not have a valid issuetype`)));
 }
 
 export default function apply(issues, jiraClientAPI) {


### PR DESCRIPTION
Closes #29.

Prints out list of issues that do not have an issue-type that are tested in [issue-strategies/index](https://github.com/TWExchangeSolutions/jira-precommit-hook/blob/master/src/issue-strategies/index.js)