### PR TITLE
Removing the update-notifier dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,8 +58,7 @@
     "fs-promise": "^0.5.0",
     "jira-client": "^1.2.0",
     "lodash": "^4.0.0",
-    "request-promise": "^2.0.0",
-    "update-notifier": "^0.6.3"
+    "request-promise": "^2.0.0"
   },
   "repository": {
     "type": "git",

--- a/src/outdated-check.js
+++ b/src/outdated-check.js
@@ -1,17 +1,17 @@
 import chalk from 'chalk';
-import pkg from '../package.json';
-import updateNotifier from 'update-notifier';
+import { name, version } from '../package.json';
+import request from 'request-promise';
 
 export default async function checkOutdated() {
-  const notifier = updateNotifier({ pkg });
+  const rawResponse = await request(`https://registry.npmjs.org/${name}/latest`);
+  const latest = JSON.parse(rawResponse).version;
 
-  if (notifier.update) {
-    const { current, latest } = notifier.update;
-    const warning = chalk.yellow(`WARNING: You are using version ${current} of the ` +
-                               `jira-precommit-hook. However, version ${latest} has been ` +
-                               'released. To update run:');
+  if (version !== latest) {
+    const warning = chalk.yellow(`WARNING: You are using version ${version} of the ` +
+                                 `jira-precommit-hook. However, version ${latest} has been ` +
+                                 'released. To update run:');
     const arrow = chalk.grey('\n> ');
-    const updateCommand = chalk.green(`npm install ${pkg.name}@${latest} --save-dev\n`);
+    const updateCommand = chalk.green(`npm install ${name}@${latest} --save-dev\n`);
     console.warn(warning + arrow + updateCommand);
   }
 }


### PR DESCRIPTION
Found issues with update-notifier not working across different projects. Seems that update-notifier is best suited for globally installed dependencies.