### PR TITLE
Added debug command for deployments config

### DIFF
--- a/src/cli-commands/configcheck.js
+++ b/src/cli-commands/configcheck.js
@@ -1,0 +1,76 @@
+import fsp from 'fs-promise';
+import fsys from 'fs';
+import path from 'path';
+const command = 'configcheck';
+
+function recursiveWalk(dir) {
+  var results = []; // eslint-disable-line no-var
+  var list = fsys.readdirSync(dir); // eslint-disable-line no-var
+  list.forEach((file) => {
+    const newfile = path.join(dir, file);
+    const stat = fsys.lstatSync(newfile);
+    if (stat && stat.isDirectory()) {
+      results = results.concat(recursiveWalk(newfile));
+    } else {
+      results.push(newfile);
+    }
+  });
+  return results;
+}
+
+export function fileFilter(filename, regexPatterns = []) {
+  if (regexPatterns.length === 0) {
+    return true;
+  }
+
+  const actualResult = regexPatterns.some((x) => filename.match(x));
+  return actualResult;
+}
+
+export default {
+  command,
+  async execute({}) {
+    console.log('Checking hubot-deployments-config.json...');
+    const workingDirectory = process.cwd();
+    const deploymentConfigPath = path.join(workingDirectory, 'hubot-deployments-config.json');
+
+    if (!fsys.existsSync(deploymentConfigPath)) {
+      console.warn(`${deploymentConfigPath} does not exist.`);
+      return 1;
+    }
+
+    const fileResult = await fsp.readFile(deploymentConfigPath);
+    var jsonResult; // eslint-disable-line no-var
+    try {
+      jsonResult = JSON.parse(fileResult);
+    } catch (err) {
+      console.error(`hubot-deployments-config.json is not a valid JSON file. ${err.message}`);
+      return 1;
+    }
+
+    console.log('hubot-deployments-config.json is valid JSON.  Showing debug file list...');
+    const fileList = recursiveWalk(workingDirectory);
+    const collectorMap = {};
+    const allRegexPatterns = [];
+
+    Object.keys(jsonResult).forEach(buildType => {
+      allRegexPatterns.push(jsonResult[buildType]);
+      collectorMap[buildType] = fileList.filter(x => fileFilter(x, jsonResult[buildType]));
+    });
+
+    console.log('Results:');
+    Object.keys(collectorMap).forEach(buildType => {
+      console.log(`Files Associated with ${buildType}:`);
+      console.log(collectorMap[buildType]);
+    });
+    console.log('Uncovered Files:');
+    console.log(fileList.filter(x => !fileFilter(x, allRegexPatterns)));
+    return 0;
+  },
+  register(subparsers) {
+    subparsers.addParser(command, {
+      addHelp: true,
+      help: `${command} help`
+    });
+  }
+};

--- a/src/cli-commands/index.js
+++ b/src/cli-commands/index.js
@@ -1,7 +1,8 @@
 import jokes from './jokes';
-
+import configcheck from './configcheck';
 const map = {
-  [jokes.command]: jokes
+  [jokes.command]: jokes,
+  [configcheck.command]: configcheck
 };
 
 export function register(parser) {


### PR DESCRIPTION
When installed, this command will list all files in the working directory, walking down directories recursively (ignoring symlinks because it uses lstat).  It will then measure that list against the hubot-deployments-config.json and list which build types the files are associated with, and give you a list of uncovered files at the end.

TW-16204